### PR TITLE
Deprecated-Meldung in PHP 8.2 vermeiden

### DIFF
--- a/lib/upload_util.php
+++ b/lib/upload_util.php
@@ -14,9 +14,15 @@ class Upload {
 	 */
 	protected $default_permissions = 0755;
 
-
 	/**
 	 * File post array
+	 *
+	 * @var array
+	 */
+	protected $file_post = array();
+
+	/**
+	 * Files post array
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION

`Deprecated: Creation of dynamic property Upload::$file_post is deprecated in redaxo\src\addons\zip_install\lib\upload_util.php on line 486`