### PR TITLE
README: GitHub API-Token setzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Plugins werden automatisch in das entsprechende Verzeichnis des zugehörigen Add
 
 ## GitHub API-Token setzen
 
-Das AddOn liefert keinen Token für die GitHub-API mit. Daher sind die Abfragen begrenzt. 
-Der Token kann z.B. in der install.php des project-AddOns oder einem eigenen wie folgt updatesicher gesetzt werden: 
+Das Add-on liefert keinen Token für die GitHub-API mit. Ohne Token sind die API-Abfragen auf 60 pro Stunde begrenzt.
+Ein persönlicher Zugriffstoken kann unter GitHub > Settings > Developer settings > Personal access tokens erstellt werden.
+Der Token benötigt mindestens 'public_repo' Berechtigung für öffentliche Repositories.
+Der Token kann z.B. in der install.php des project-Add-ons oder einem eigenen wie folgt updatesicher gesetzt werden:
 
 ```
 $addon = rex_addon::get('zip_install');

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Plugins werden automatisch in das entsprechende Verzeichnis des zugehörigen Add
 *   Die `update.php` des AddOns wird nicht ausgeführt.
 *   Der Upload ist auf 50 MB begrenzt.
 
+## GitHub API-Token setzen
+
+Das AddOn liefert keinen Token für die GitHub-API mit. Daher sind die Abfragen begrenzt. 
+Der Token kann z.B. in der install.php des project-AddOns oder einem eigenen wie folgt updatesicher gesetzt werden: 
+
+```
+$addon = rex_addon::get('zip_install');
+$addon->setConfig('github_token', 'GitHubToken');
+```
+
 ## Voraussetzungen
 
 *   REDAXO >= 5.18


### PR DESCRIPTION
GitHub API-Token setzen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a section in README.md for setting up GitHub API token.
	- Provided instructions for creating a personal access token with required permissions.
	- Included a code snippet for securely configuring the GitHub token in the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->